### PR TITLE
Fix/min-space-calculation

### DIFF
--- a/programs/thread/src/instructions/thread_create.rs
+++ b/programs/thread/src/instructions/thread_create.rs
@@ -30,7 +30,7 @@ pub struct ThreadCreate<'info> {
             domain.as_ref().unwrap_or(&Vec::new()).as_slice()
         ],
         bump,
-        payer= payer,
+        payer = payer,
         space = Thread::min_space(&instructions)?
     )]
     pub thread: Account<'info, Thread>,

--- a/programs/thread/src/state/thread.rs
+++ b/programs/thread/src/state/thread.rs
@@ -71,8 +71,12 @@ pub trait ThreadAccount {
 
 impl Thread {
     pub fn min_space(instructions: &[SerializableInstruction]) -> Result<usize> {
-        let ins_number = instructions.len();
         let ins_space = instructions.try_to_vec()?.len();
+        let max_ins_size = instructions
+            .iter()
+            .map(|ins| ins.try_to_vec().map(|v| v.len()).unwrap_or(0))
+            .max()
+            .unwrap_or(0);
 
         Ok(
             8
@@ -84,7 +88,7 @@ impl Thread {
             + u64::MIN_SPACE // fee
             + (4 + 32) // id
             + (4 + ins_space) // instructions
-            + (1 + ins_space / ins_number) // next_instruction
+            + (1 + max_ins_size) // next_instruction
             + bool::MIN_SPACE // paused
             + u64::MIN_SPACE // rate_limit
             + Trigger::MIN_SPACE, // trigger


### PR DESCRIPTION
If multiple instructions, should have space for the biggest one in next